### PR TITLE
Pass path to docker build command

### DIFF
--- a/pkg/dockerimage/build.go
+++ b/pkg/dockerimage/build.go
@@ -1,17 +1,13 @@
 package dockerimage
 
-import "os"
+import "path/filepath"
 
 // BuildFromContainerfile builds a Container image from a Containerfile.
 // Invokes docker via CLI since Docker's dependencies and API are beyond brittle.
 func BuildFromContainerfile(path string, tag string) error {
-
-	dir, _ := os.Getwd()
-	os.Chdir(path)
-	defer os.Chdir(dir)
 	// Normally you would want to use a Golang API here.
 	// Since the Docker API is a very thin shim, badly documented
 	// and talking to Dockerd or Buildkit has a lot of quirks
 	// just call the binary here and be done with it.
-	return executeDockerCommand("build", "-f", "Containerfile", ".", "-t", tag)
+	return executeDockerCommand("build", "-f", filepath.Join(path, "Containerfile"), path, "-t", tag)
 }


### PR DESCRIPTION
 - changing the working dir will get us in problems when containers are build parallel