### PR TITLE
Add kubernetes as required_provider to service_container

### DIFF
--- a/tf/service_container/provider.tf
+++ b/tf/service_container/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
This gives us the ability to pass a provider into the module which gets used instead of the "default"