### PR TITLE
Add public access prevention variable to bucket module

### DIFF
--- a/tf/bucket/main.tf
+++ b/tf/bucket/main.tf
@@ -31,6 +31,7 @@ resource "google_storage_bucket" "main" {
   location = var.location
 
   force_destroy               = var.force_destroy
+  public_access_prevention    = "enforced"
   uniform_bucket_level_access = true
 
   dynamic "retention_policy" {


### PR DESCRIPTION
resource default is inherited which seem to be a bit to implicit for us